### PR TITLE
change .views to views #line12. ".views" gives an error. WebfontsApiView belong to views.py

### DIFF
--- a/flaskext/webfonts.py
+++ b/flaskext/webfonts.py
@@ -9,7 +9,7 @@ using the fonts as webfonts.
     :license: BSD, see LICENSE for more details.
 """
 
-from .views import (WebfontsApiView, WebfontsListView,
+from views import (WebfontsApiView, WebfontsListView,
                     WebfontsPreviewTextView, WebfontsGalleryView)
 from flask import Blueprint
 from text import text


### PR DESCRIPTION
 ".views" gives an error because no module named .views. 
WebfontsApiView WebfontsListView belong to views.py. 
